### PR TITLE
aarch64: Fix IMAGE_REL_ARM64_PAGEBASE_REL21 relocation and symbol reduction for relocations

### DIFF
--- a/bfd/coff-aarch64.c
+++ b/bfd/coff-aarch64.c
@@ -78,8 +78,9 @@ coff_aarch64_rel21_reloc (bfd *abfd,
       relocation -= (reloc_entry->address
 		     + input_section->output_offset
 		     + input_section->output_section->vma);
-      relocation = (bfd_signed_vma) relocation >> reloc_entry->howto->rightshift;
     }
+
+  relocation = (bfd_signed_vma) relocation >> reloc_entry->howto->rightshift;
   if (relocation + 0x100000 > 0x1fffff)
     ret = bfd_reloc_overflow;
 
@@ -579,8 +580,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 		input_section, rel->r_vaddr - input_section->vma);
 
 	    bfd_putl32 (val, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -614,7 +614,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= val & 0x3ffffff;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
+		rel->r_vaddr = -1;
 
 	    break;
 	  }
@@ -649,8 +649,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= (val & 0x7ffff) << 5;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -684,8 +683,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= (val & 0x3fff) << 5;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -702,6 +700,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 
 	    if (addend & 0x100000)
 	      addend |= 0xffffffffffe00000;
+	    addend <<= 12;
 
 	    dest_vma += addend;
 	    cur_vma = input_section->output_section->vma
@@ -721,7 +720,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= (val & 0x1ffffc) << 3;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
+		rel->r_vaddr = -1;
 
 	    break;
 	  }
@@ -758,8 +757,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= (val & 0x1ffffc) << 3;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -787,8 +785,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 		input_section, rel->r_vaddr - input_section->vma);
 
 	    bfd_putl32 (val, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -832,8 +829,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= val << 10;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -855,8 +851,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= val << 10;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -876,8 +871,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 		input_section, rel->r_vaddr - input_section->vma);
 
 	    bfd_putl32 (val, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -901,8 +895,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 
 
 	    bfd_putl16 (idx, contents + rel->r_vaddr);
-	    rel->r_type = IMAGE_REL_ARM64_ABSOLUTE;
-
+		rel->r_vaddr = -1;
 	    break;
 	  }
 

--- a/bfd/coff-aarch64.c
+++ b/bfd/coff-aarch64.c
@@ -580,7 +580,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 		input_section, rel->r_vaddr - input_section->vma);
 
 	    bfd_putl32 (val, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -614,7 +614,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= val & 0x3ffffff;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 
 	    break;
 	  }
@@ -649,7 +649,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= (val & 0x7ffff) << 5;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -683,7 +683,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= (val & 0x3fff) << 5;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -720,7 +720,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= (val & 0x1ffffc) << 3;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 
 	    break;
 	  }
@@ -757,7 +757,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= (val & 0x1ffffc) << 3;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -785,7 +785,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 		input_section, rel->r_vaddr - input_section->vma);
 
 	    bfd_putl32 (val, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -829,7 +829,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= val << 10;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -851,7 +851,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 	    opcode |= val << 10;
 
 	    bfd_putl32 (opcode, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -871,7 +871,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 		input_section, rel->r_vaddr - input_section->vma);
 
 	    bfd_putl32 (val, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 
@@ -895,7 +895,7 @@ coff_pe_aarch64_relocate_section (bfd *output_bfd,
 
 
 	    bfd_putl16 (idx, contents + rel->r_vaddr);
-		rel->r_vaddr = -1;
+	    rel->r_vaddr = -1;
 	    break;
 	  }
 

--- a/bfd/cofflink.c
+++ b/bfd/cofflink.c
@@ -2934,8 +2934,8 @@ _bfd_coff_generic_relocate_section (bfd *output_bfd,
 
       symndx = rel->r_symndx;
 
-	  if (rel->r_vaddr == (bfd_vma) -1)
-	  	continue;
+      if (rel->r_vaddr == (bfd_vma) -1)
+	continue;
 
       if (symndx == -1)
 	{

--- a/bfd/cofflink.c
+++ b/bfd/cofflink.c
@@ -2934,6 +2934,9 @@ _bfd_coff_generic_relocate_section (bfd *output_bfd,
 
       symndx = rel->r_symndx;
 
+	  if (rel->r_vaddr == (bfd_vma) -1)
+	  	continue;
+
       if (symndx == -1)
 	{
 	  h = NULL;

--- a/gas/symbols.c
+++ b/gas/symbols.c
@@ -2423,7 +2423,7 @@ S_SHOULD_BE_REDUCED_TO_SECTION_NAME (const symbolS *s) {
   if (!strncmp(".L", s->name, 2))
     return false;
 
-  if (!strcmp(".rdata", s->bsym->section->name))
+  if (!strcmp(".rdata", s->bsym->section->name) || !strcmp(".data", s->bsym->section->name))
     return false;
 
 #else

--- a/gas/symbols.c
+++ b/gas/symbols.c
@@ -2417,20 +2417,20 @@ S_IS_DEBUG (const symbolS *s)
 int
 S_SHOULD_BE_REDUCED_TO_SECTION_NAME (const symbolS *s) {
 #if defined(COFFAARCH64)
-  if (S_GET_STORAGE_CLASS ((symbolS *)s) == C_STAT)
-    return false;
+  if (S_GET_STORAGE_CLASS ((symbolS *) s) == C_STAT)
+    return 0;
 
   if (!strncmp(".L", s->name, 2))
-    return false;
+    return 0;
 
   if (!strcmp(".rdata", s->bsym->section->name) || !strcmp(".data", s->bsym->section->name))
-    return false;
+    return 0;
 
 #else
   (void) s; /* Avoid unused variable warning.  */
 #endif
 
-  return true;
+  return 1;
 }
 
 int

--- a/gas/symbols.c
+++ b/gas/symbols.c
@@ -2415,6 +2415,21 @@ S_IS_DEBUG (const symbolS *s)
 }
 
 int
+S_SHOULD_BE_REDUCED_TO_SECTION_NAME (const symbolS *s) {
+#if defined(COFFAARCH64)
+  if (S_GET_STORAGE_CLASS ((symbolS *)s) == C_STAT)
+    return false;
+
+  if (!strncmp(".L", s->name, 2))
+    return false;
+#else
+  (void) s; /* Avoid unused variable warning.  */
+#endif
+
+  return true;
+}
+
+int
 S_IS_LOCAL (const symbolS *s)
 {
   flagword flags;

--- a/gas/symbols.c
+++ b/gas/symbols.c
@@ -2422,6 +2422,10 @@ S_SHOULD_BE_REDUCED_TO_SECTION_NAME (const symbolS *s) {
 
   if (!strncmp(".L", s->name, 2))
     return false;
+
+  if (!strcmp(".rdata", s->bsym->section->name))
+    return false;
+
 #else
   (void) s; /* Avoid unused variable warning.  */
 #endif

--- a/gas/symbols.h
+++ b/gas/symbols.h
@@ -124,6 +124,8 @@ extern void S_SET_THREAD_LOCAL (symbolS *);
 extern void S_SET_VOLATILE (symbolS *);
 extern void S_CLEAR_VOLATILE (symbolS *);
 extern void S_SET_FORWARD_REF (symbolS *);
+extern int S_SHOULD_BE_REDUCED_TO_SECTION_NAME (const symbolS *s);
+
 
 #ifndef WORKING_DOT_WORD
 struct broken_word

--- a/gas/write.c
+++ b/gas/write.c
@@ -891,6 +891,9 @@ adjust_reloc_syms (bfd *abfd ATTRIBUTE_UNUSED,
 	if ((symsec->flags & SEC_THREAD_LOCAL) != 0)
 	  continue;
 
+	if (!S_SHOULD_BE_REDUCED_TO_SECTION_NAME (sym))
+		continue;
+
 	val = S_GET_VALUE (sym);
 
 #if defined(TC_AARCH64) && defined(OBJ_COFF)


### PR DESCRIPTION
Initially, the change was to fix IMAGE_REL_ARM64_PAGEBASE_REL21, which was addressing only 1MB instead of 4GB.
This change triggered multiple changes in binutils and gcc to support the small code model.

Probably, rel->r_type = IMAGE_REL_ARM64_ABSOLUTE was done on purpose to bypass changes in processed relocations in a later call to _bfd_coff_generic_relocate_section. However, it was breaking the relocation reduction logic, as the initial relocation type was no longer known. All PE relocations have been replaced with IMAGE_REL_ARM64_ABSOLUTE.
To avoid extra processing and introducing an extra field in the relocation structure,  
rel->r_type = IMAGE_REL_ARM64_ABSOLUTE has been replaced with rel->r_vaddr = -1,
and a check to skip relocation processing has been added to _bfd_coff_generic_relocate_section.

In one of the relocation processing steps, there is logic to reduce a symbol name to a section name where it is placed.
In the COFF format on AArch64, this should not happen for symbols used in relocations that cannot be fully handled at the object compiling time. This information will be used by the linker to make correct relocation. Otherwise, it can lead to a silent relocation overflow during the linking step because the linker assumes everything looks good, which most likely results in a crash upon execution.

To resolve this issue, S_SHOULD_BE_REDUCED_TO_SECTION_NAME has been added.
It is still a prototype and will be refactored before submitting the patch series to the mailing list.

This fix relies on changes in gcc.
[aarch64: Multiple adjustments to support the SMALL code model correctly
](https://github.com/Windows-on-ARM-Experiments/gcc-woarm64/pull/23)

This change resolves the following issues:
[Relocation overflow when a struct is large](https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/130)
[Relocation overflow issue when building FFmpeg with -O3](https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/100)

Tested with CI:
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/9600219765