### PR TITLE
Add aarch64 support to libiberty

### DIFF
--- a/libiberty/simple-object-coff.c
+++ b/libiberty/simple-object-coff.c
@@ -219,7 +219,9 @@ static const struct coff_magic_struct coff_magic[] =
   /* i386.  */
   { 0x14c, 0, F_EXEC | IMAGE_FILE_SYSTEM | IMAGE_FILE_DLL },
   /* x86_64.  */
-  { 0x8664, 0, F_EXEC | IMAGE_FILE_SYSTEM | IMAGE_FILE_DLL }
+  { 0x8664, 0, F_EXEC | IMAGE_FILE_SYSTEM | IMAGE_FILE_DLL },
+  /* AArch64.  */
+  { 0xaa64, 0, F_EXEC | IMAGE_FILE_SYSTEM | IMAGE_FILE_DLL }
 };
 
 /* See if we have a COFF file.  */


### PR DESCRIPTION
The patch adds aarch64 architecture to the list of supported COFF headers.

Validated with CI
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/9879475395
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/9888893952