### PR TITLE
Add big object support for aarch64 PE

### DIFF
--- a/bfd/coff-aarch64.c
+++ b/bfd/coff-aarch64.c
@@ -1030,3 +1030,78 @@ const bfd_target
 
   COFF_SWAP_TABLE
 };
+
+#ifdef COFF_WITH_PE_BIGOBJ
+const bfd_target
+  TARGET_SYM_BIG =
+{
+  TARGET_NAME_BIG,
+  bfd_target_coff_flavour,
+  BFD_ENDIAN_LITTLE,		/* Data byte order is little.  */
+  BFD_ENDIAN_LITTLE,		/* Header byte order is little.  */
+
+  (HAS_RELOC | EXEC_P		/* Object flags.  */
+   | HAS_LINENO | HAS_DEBUG
+   | HAS_SYMS | HAS_LOCALS | WP_TEXT | D_PAGED | BFD_COMPRESS | BFD_DECOMPRESS),
+
+  (SEC_HAS_CONTENTS | SEC_ALLOC | SEC_LOAD | SEC_RELOC /* Section flags.  */
+#ifdef COFF_WITH_PE
+   | SEC_LINK_ONCE | SEC_LINK_DUPLICATES | SEC_READONLY | SEC_DEBUGGING
+#endif
+   | SEC_CODE | SEC_DATA | SEC_EXCLUDE ),
+
+#ifdef TARGET_UNDERSCORE
+  TARGET_UNDERSCORE,		/* Leading underscore.  */
+#else
+  0,				/* Leading underscore.  */
+#endif
+  '/',				/* Ar_pad_char.  */
+  15,				/* Ar_max_namelen.  */
+  0,				/* match priority.  */
+  TARGET_KEEP_UNUSED_SECTION_SYMBOLS, /* keep unused section symbols.  */
+
+  /* Data conversion functions.  */
+  bfd_getl64, bfd_getl_signed_64, bfd_putl64,
+  bfd_getl32, bfd_getl_signed_32, bfd_putl32,
+  bfd_getl16, bfd_getl_signed_16, bfd_putl16, /* Data.  */
+  /* Header conversion functions.  */
+  bfd_getl64, bfd_getl_signed_64, bfd_putl64,
+  bfd_getl32, bfd_getl_signed_32, bfd_putl32,
+  bfd_getl16, bfd_getl_signed_16, bfd_putl16, /* Hdrs.  */
+
+  /* Note that we allow an object file to be treated as a core file as well.  */
+  {				/* bfd_check_format.  */
+    _bfd_dummy_target,
+    coff_object_p,
+    bfd_generic_archive_p,
+    coff_object_p
+  },
+  {				/* bfd_set_format.  */
+    _bfd_bool_bfd_false_error,
+    coff_mkobject,
+    _bfd_generic_mkarchive,
+    _bfd_bool_bfd_false_error
+  },
+  {				/* bfd_write_contents.  */
+    _bfd_bool_bfd_false_error,
+    coff_write_object_contents,
+    _bfd_write_archive_contents,
+    _bfd_bool_bfd_false_error
+  },
+
+  BFD_JUMP_TABLE_GENERIC (coff_aarch64),
+  BFD_JUMP_TABLE_COPY (coff),
+  BFD_JUMP_TABLE_CORE (_bfd_nocore),
+  BFD_JUMP_TABLE_ARCHIVE (_bfd_archive_coff),
+  BFD_JUMP_TABLE_SYMBOLS (coff),
+  BFD_JUMP_TABLE_RELOCS (coff),
+  BFD_JUMP_TABLE_WRITE (coff),
+  BFD_JUMP_TABLE_LINK (coff),
+  BFD_JUMP_TABLE_DYNAMIC (_bfd_nodynamic),
+
+  NULL,
+
+  &bigobj_swap_table
+};
+#endif
+

--- a/bfd/config.bfd
+++ b/bfd/config.bfd
@@ -250,7 +250,7 @@ case "${targ}" in
     ;;
   aarch64-*-pe* | aarch64-*-mingw*)
     targ_defvec=aarch64_pe_le_vec
-    targ_selvecs="aarch64_pe_le_vec aarch64_pei_le_vec aarch64_elf64_le_vec aarch64_elf64_be_vec aarch64_elf32_le_vec aarch64_elf32_be_vec arm_elf32_le_vec arm_elf32_be_vec pdb_vec"
+    targ_selvecs="aarch64_pe_le_vec aarch64_pei_le_vec aarch64_pe_big_vec aarch64_elf64_le_vec aarch64_elf64_be_vec aarch64_elf32_le_vec aarch64_elf32_be_vec arm_elf32_le_vec arm_elf32_be_vec pdb_vec"
     want64=true
     targ_underscore=no
     ;;

--- a/bfd/configure
+++ b/bfd/configure
@@ -15824,6 +15824,7 @@ do
     aarch64_mach_o_vec)		 tb="$tb mach-o-aarch64.lo"; target_size=64 ;;
     aarch64_pei_le_vec)		 tb="$tb pei-aarch64.lo pe-aarch64igen.lo $coff"; target_size=64 ;;
     aarch64_pe_le_vec)		 tb="$tb pe-aarch64.lo pe-aarch64igen.lo $coff"; target_size=64 ;;
+    aarch64_pe_big_vec)		 tb="$tb pe-aarch64.lo pe-aarch64igen.lo $coff"; target_size=64 ;;
     alpha_ecoff_le_vec)		 tb="$tb coff-alpha.lo ecoff.lo $ecoff"; target_size=64 ;;
     alpha_elf64_vec)		 tb="$tb elf64-alpha.lo elf64.lo $elf"; target_size=64 ;;
     alpha_elf64_fbsd_vec)	 tb="$tb elf64-alpha.lo elf64.lo $elf"; target_size=64 ;;

--- a/bfd/configure.ac
+++ b/bfd/configure.ac
@@ -410,6 +410,7 @@ do
     aarch64_mach_o_vec)		 tb="$tb mach-o-aarch64.lo"; target_size=64 ;;
     aarch64_pei_le_vec)		 tb="$tb pei-aarch64.lo pe-aarch64igen.lo $coff"; target_size=64 ;;
     aarch64_pe_le_vec)		 tb="$tb pe-aarch64.lo pe-aarch64igen.lo $coff"; target_size=64 ;;
+    aarch64_pe_big_vec)		 tb="$tb pe-aarch64.lo pe-aarch64igen.lo $coff"; target_size=64 ;;
     alpha_ecoff_le_vec)		 tb="$tb coff-alpha.lo ecoff.lo $ecoff"; target_size=64 ;;
     alpha_elf64_vec)		 tb="$tb elf64-alpha.lo elf64.lo $elf"; target_size=64 ;;
     alpha_elf64_fbsd_vec)	 tb="$tb elf64-alpha.lo elf64.lo $elf"; target_size=64 ;;

--- a/bfd/cpu-aarch64.c
+++ b/bfd/cpu-aarch64.c
@@ -115,7 +115,7 @@ scan (const struct bfd_arch_info *info, const char *string)
 }
 
 /* Figure out if llp64 is default */
-#if DEFAULT_VECTOR == aarch64_pe_le_vec
+#if DEFAULT_VECTOR == aarch64_pe_le_vec || DEFAULT_VECTOR == aarch64_pe_big_vec
 #define LLP64_DEFAULT true
 #define AARCH64_DEFAULT false
 #else

--- a/bfd/pe-aarch64.c
+++ b/bfd/pe-aarch64.c
@@ -23,6 +23,8 @@
 
 #define TARGET_SYM             aarch64_pe_le_vec
 #define TARGET_NAME            "pe-aarch64-little"
+#define TARGET_SYM_BIG		     aarch64_pe_big_vec
+#define TARGET_NAME_BIG		     "pe-aarch64-bigobj"
 #define TARGET_ARCHITECTURE    bfd_arch_aarch64
 #define TARGET_PAGESIZE        4096
 #define TARGET_BIG_ENDIAN      0
@@ -32,6 +34,7 @@
 /* Rename the above into.. */
 #define COFF_WITH_peAArch64
 #define COFF_WITH_PE
+#define COFF_WITH_PE_BIGOBJ
 #define PCRELOFFSET       true
 
 /* Long section names not allowed in executable images, only object files.  */

--- a/bfd/pe-aarch64.c
+++ b/bfd/pe-aarch64.c
@@ -23,8 +23,8 @@
 
 #define TARGET_SYM             aarch64_pe_le_vec
 #define TARGET_NAME            "pe-aarch64-little"
-#define TARGET_SYM_BIG		     aarch64_pe_big_vec
-#define TARGET_NAME_BIG		     "pe-aarch64-bigobj"
+#define TARGET_SYM_BIG         aarch64_pe_big_vec
+#define TARGET_NAME_BIG        "pe-aarch64-bigobj"
 #define TARGET_ARCHITECTURE    bfd_arch_aarch64
 #define TARGET_PAGESIZE        4096
 #define TARGET_BIG_ENDIAN      0

--- a/bfd/targets.c
+++ b/bfd/targets.c
@@ -682,6 +682,7 @@ extern const bfd_target aarch64_elf64_le_cloudabi_vec;
 extern const bfd_target aarch64_mach_o_vec;
 extern const bfd_target aarch64_pei_le_vec;
 extern const bfd_target aarch64_pe_le_vec;
+extern const bfd_target aarch64_pe_big_vec;
 extern const bfd_target alpha_ecoff_le_vec;
 extern const bfd_target alpha_elf64_vec;
 extern const bfd_target alpha_elf64_fbsd_vec;
@@ -994,6 +995,7 @@ static const bfd_target * const _bfd_target_vector[] =
 	&aarch64_elf64_le_cloudabi_vec,
 	&aarch64_mach_o_vec,
 	&aarch64_pe_le_vec,
+    &aarch64_pe_big_vec,
 	&aarch64_pei_le_vec,
 #endif
 

--- a/bfd/targets.c
+++ b/bfd/targets.c
@@ -995,7 +995,7 @@ static const bfd_target * const _bfd_target_vector[] =
 	&aarch64_elf64_le_cloudabi_vec,
 	&aarch64_mach_o_vec,
 	&aarch64_pe_le_vec,
-    &aarch64_pe_big_vec,
+	&aarch64_pe_big_vec,
 	&aarch64_pei_le_vec,
 #endif
 

--- a/gas/config/tc-aarch64.c
+++ b/gas/config/tc-aarch64.c
@@ -10137,7 +10137,7 @@ aarch64elf_frob_symbol (symbolS * symp, int *puntp)
 const char *
 coff_aarch64_target_format (void)
 {
-  return "pe-aarch64-little";
+  return "pe-aarch64-bigobj";
 }
 #endif
 

--- a/gas/config/tc-aarch64.c
+++ b/gas/config/tc-aarch64.c
@@ -10110,7 +10110,7 @@ aarch64_after_parse_args (void)
 #endif
 }
 
-#if defined (TE_PE) || defined (TE_PEP)
+#ifdef OBJ_COFF
 /* Use big object file format.  */
 static int use_big_obj = 0;
 #endif
@@ -10498,7 +10498,7 @@ const struct option md_longopts[] = {
 #ifdef OPTION_EL
   {"EL", no_argument, NULL, OPTION_EL},
 #endif
-# if defined (TE_PE) || defined (TE_PEP)
+#ifdef OBJ_COFF
   {"mbig-obj", no_argument, NULL, OPTION_MBIG_OBJ},
 #endif
   {NULL, no_argument, NULL, 0}
@@ -11068,7 +11068,7 @@ md_parse_option (int c, const char *arg)
       break;
 #endif
 
-# if defined (TE_PE) || defined (TE_PEP)
+#ifdef OBJ_COFF
     case OPTION_MBIG_OBJ:
       use_big_obj = 1;
       break;
@@ -11147,7 +11147,7 @@ md_show_usage (FILE * fp)
   -EL                     assemble code for a little-endian cpu\n"));
 #endif
 
-#if defined (TE_PE) || defined (TE_PEP)
+#ifdef OBJ_COFF
   fprintf (fp, _("\
   -mbig-obj               generate big object files\n"));
 #endif

--- a/gas/config/tc-aarch64.c
+++ b/gas/config/tc-aarch64.c
@@ -10110,6 +10110,11 @@ aarch64_after_parse_args (void)
 #endif
 }
 
+#if defined (TE_PE) || defined (TE_PEP)
+/* Use big object file format.  */
+static int use_big_obj = 0;
+#endif
+
 #ifdef OBJ_ELF
 const char *
 elf64_aarch64_target_format (void)
@@ -10137,7 +10142,7 @@ aarch64elf_frob_symbol (symbolS * symp, int *puntp)
 const char *
 coff_aarch64_target_format (void)
 {
-  return "pe-aarch64-bigobj";
+  return use_big_obj ? "pe-aarch64-bigobj" : "pe-aarch64-little";
 }
 #endif
 
@@ -10484,6 +10489,7 @@ const char md_shortopts[] = "m:";
 #define OPTION_EL (OPTION_MD_BASE + 1)
 #endif
 #endif
+#define OPTION_MBIG_OBJ (OPTION_MD_BASE + 2)
 
 const struct option md_longopts[] = {
 #ifdef OPTION_EB
@@ -10491,6 +10497,9 @@ const struct option md_longopts[] = {
 #endif
 #ifdef OPTION_EL
   {"EL", no_argument, NULL, OPTION_EL},
+#endif
+# if defined (TE_PE) || defined (TE_PEP)
+  {"mbig-obj", no_argument, NULL, OPTION_MBIG_OBJ},
 #endif
   {NULL, no_argument, NULL, 0}
 };
@@ -11059,6 +11068,12 @@ md_parse_option (int c, const char *arg)
       break;
 #endif
 
+# if defined (TE_PE) || defined (TE_PEP)
+    case OPTION_MBIG_OBJ:
+      use_big_obj = 1;
+      break;
+#endif
+
     case 'a':
       /* Listing option.  Just ignore these, we don't support additional
          ones.  */
@@ -11130,6 +11145,11 @@ md_show_usage (FILE * fp)
 #ifdef OPTION_EL
   fprintf (fp, _("\
   -EL                     assemble code for a little-endian cpu\n"));
+#endif
+
+#if defined (TE_PE) || defined (TE_PEP)
+  fprintf (fp, _("\
+  -mbig-obj               generate big object files\n"));
 #endif
 }
 

--- a/gas/testsuite/gas/pe/big-obj.d
+++ b/gas/testsuite/gas/pe/big-obj.d
@@ -2,7 +2,7 @@
 #objdump: -h
 #name: PE big obj
 
-.*: *file format pe-bigobj-.*
+.*: *file format (pe-bigobj-.*|pe-aarch64-bigobj)
 
 Sections:
 #...

--- a/ld/pe-dll.c
+++ b/ld/pe-dll.c
@@ -359,6 +359,18 @@ static pe_details_type pe_detail_list[] =
     false,
     autofilter_symbollist_generic
   },
+  {
+    "pei-aarch64-little",
+    "pe-aarch64-bigobj",
+    2,  /* IMAGE_REL_ARM64_ADDR32NB */
+    8,  /* IMAGE_REL_ARM64_SECREL */
+    11, /* IMAGE_REL_ARM64_SECREL_LOW12L */
+    13, /* IMAGE_REL_ARM64_SECTION */
+    PE_ARCH_aarch64,
+    bfd_arch_aarch64,
+    false,
+    autofilter_symbollist_generic
+  },
   { NULL, NULL, 0, 0, 0, 0, 0, 0, false, NULL }
 };
 


### PR DESCRIPTION
Adds support for big objects in the aarch64 COFF target in `aarch64-w64-mingw32-as` which can be enabled with `-mbig-obj` argument. Without this creating binary with a lot of sections fails with the error like:

```
/home/vejby/cross-aarch64-w64-mingw32-msvcrt/bin/aarch64-w64-mingw32-as: a.out: too many sections (50004)
code/binutils/gas/testsuite/gas/pe/big-obj.s: Assembler messages:
code/binutils/gas/testsuite/gas/pe/big-obj.s: Fatal error: can't write 1 byte to section .data$a00000 of a.out: 'file too big'
/home/vejby/cross-aarch64-w64-mingw32-msvcrt/bin/aarch64-w64-mingw32-as: a.out: too many sections (50004)
code/binutils/gas/testsuite/gas/pe/big-obj.s: Fatal error: a.out: file too big
```

Based on [this MSVC documentation](https://learn.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-170), this should manifest if you want to create more than 2^16 sections but it actually happens already somewhere between 2^15 and 2^16.