### PR TITLE
Add `aarch64-pc-cygwin` target

### DIFF
--- a/bfd/config.bfd
+++ b/bfd/config.bfd
@@ -248,7 +248,7 @@ case "${targ}" in
     targ_selvecs="aarch64_elf64_be_vec aarch64_elf32_le_vec aarch64_elf32_be_vec arm_elf32_le_vec arm_elf32_be_vec aarch64_pei_le_vec aarch64_pe_le_vec"
     want64=true
     ;;
-  aarch64-*-pe* | aarch64-*-mingw*)
+  aarch64-*-pe* | aarch64-*-mingw* | aarch64-*-cygwin*)
     targ_defvec=aarch64_pe_le_vec
     targ_selvecs="aarch64_pe_le_vec aarch64_pei_le_vec aarch64_pe_big_vec aarch64_elf64_le_vec aarch64_elf64_be_vec aarch64_elf32_le_vec aarch64_elf32_be_vec arm_elf32_le_vec arm_elf32_be_vec pdb_vec"
     want64=true

--- a/binutils/configure
+++ b/binutils/configure
@@ -16419,7 +16419,7 @@ do
     esac
 
     case $targ in
-    aarch64-*-mingw*)
+    aarch64-*-mingw* | aarch64-*-cygwin*)
 	BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
 	if test -z "$DLLTOOL_DEFAULT"; then
 	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_AARCH64"

--- a/binutils/configure.ac
+++ b/binutils/configure.ac
@@ -368,7 +368,7 @@ changequote([,])dnl
     esac
 
     case $targ in
-    aarch64-*-mingw*)
+    aarch64-*-mingw*| aarch64-*-cygwin* )
 	BUILD_DLLTOOL='$(DLLTOOL_PROG)$(EXEEXT)'
 	if test -z "$DLLTOOL_DEFAULT"; then
 	    DLLTOOL_DEFAULT="-DDLLTOOL_DEFAULT_AARCH64"

--- a/config.guess
+++ b/config.guess
@@ -955,6 +955,9 @@ EOF
     i*:UWIN*:*)
 	GUESS=$UNAME_MACHINE-pc-uwin
 	;;
+    aarch64:CYGWIN*:*:*)
+	GUESS=aarch64-pc-cygwin
+	;;
     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
 	GUESS=x86_64-pc-cygwin
 	;;

--- a/config.rpath
+++ b/config.rpath
@@ -439,7 +439,7 @@ case "$host_os" in
     ;;
   cygwin* | mingw* | pw32*)
     case "$TOOLCHAIN_TARGET" in
-      i686-w64-mingw32 | x86_64-w64-mingw32)
+      aarch64-w64-mingw32 | i686-w64-mingw32 | x86_64-w64-mingw32)
 	shrext=.dll.a
 	;;
       *)

--- a/config.rpath
+++ b/config.rpath
@@ -438,7 +438,14 @@ case "$host_os" in
   bsdi4*)
     ;;
   cygwin* | mingw* | pw32*)
-    shrext=.dll
+    case "$TOOLCHAIN_TARGET" in
+      i686-w64-mingw32 | x86_64-w64-mingw32)
+	shrext=.dll.a
+	;;
+      *)
+	shrext=.dll
+	;;
+    esac
     ;;
   darwin* | rhapsody*)
     shrext=.dylib

--- a/gas/configure.tgt
+++ b/gas/configure.tgt
@@ -138,7 +138,7 @@ case ${generic_target} in
   aarch64*-*-netbsd*)			fmt=elf em=nbsd;;
   aarch64*-*-nto*)			fmt=elf;;
   aarch64*-*-openbsd*)			fmt=elf;;
-  aarch64*-*-pe* | aarch64*-*-mingw*)	fmt=coff em=pepaarch64 ;;
+  aarch64*-*-pe* | aarch64*-*-mingw* | aarch64*-*-cygwin*)	fmt=coff em=pepaarch64 ;;
   alpha-*-*vms*)			fmt=evax ;;
   alpha-*-osf*)				fmt=ecoff ;;
   alpha-*-linux*ecoff*)			fmt=ecoff ;;

--- a/gdb/configure.host
+++ b/gdb/configure.host
@@ -81,6 +81,7 @@ case "${host}" in
 
 aarch64*-*-linux*)	gdb_host=linux ;;
 aarch64*-*-freebsd*)	gdb_host=fbsd ;;
+aarch64*-*-cygwin*)	gdb_host=cygwin64 ;;
 
 alpha*-*-linux*)	gdb_host=alpha-linux ;;
 alpha*-*-netbsdaout* | alpha*-*-knetbsdaout*-gnu)

--- a/gdbserver/configure.srv
+++ b/gdbserver/configure.srv
@@ -67,6 +67,13 @@ case "${gdbserver_host}" in
 			srv_tgtobj="${srv_tgtobj} nat/netbsd-nat.o"
 			srv_tgtobj="${srv_tgtobj} arch/aarch64-insn.o arch/aarch64.o"
 			;;
+  aarch64-*-cygwin*)	srv_regobj=""
+			srv_tgtobj="aarch64-low.o nat/aarch64-dregs.o"
+			srv_tgtobj="${srv_tgtobj} nat/aarch64-xstate.o aarch64-fp.o"
+			srv_tgtobj="${srv_tgtobj} win32-low.o win32-aarch64-low.o"
+			srv_tgtobj="${srv_tgtobj} nat/windows-nat.o"
+			srv_tgtobj="${srv_tgtobj} arch/aarch64.o"
+			;;
   arc*-*-linux*)
 			srv_regobj=""
 			srv_tgtobj="linux-arc-low.o arch/arc.o $srv_linux_obj"

--- a/ld/configure.tgt
+++ b/ld/configure.tgt
@@ -127,7 +127,7 @@ aarch64-*-haiku*)	targ_emul=aarch64haiku
 aarch64-*-nto*)		targ_emul=aarch64nto
 			targ_extra_emuls="aarch64elf aarch64elf32 aarch64elf32b aarch64elfb armelf armelfb"
 			;;
-aarch64-*-pe* | aarch64-*-mingw*)
+aarch64-*-pe* | aarch64-*-mingw* | aarch64-*-cygwin*)
 			targ_emul=aarch64pe
 			targ_extra_emuls=arm64pe
 			targ_extra_ofiles="deffilep.o pep-dll-aarch64.o pe-dll.o pdb.o"
@@ -1141,7 +1141,7 @@ spu-*-elf*)
   NATIVE_LIB_DIRS='/lib'
   ;;
 
-i[03-9x]86-*-cygwin* | x86_64-*-cygwin*)
+aarch64-*-cygwin* | i[03-9x]86-*-cygwin* | x86_64-*-cygwin*)
   NATIVE_LIB_DIRS='/usr/lib /usr/lib/w32api'
   ;;
 

--- a/ld/emultempl/pe.em
+++ b/ld/emultempl/pe.em
@@ -7,6 +7,9 @@ else
 fi
 
 case ${target} in
+  aarch64-*-cygwin*)
+    cygwin_behavior=0;
+    ;;
   *-*-cygwin*)
     cygwin_behavior=1
     ;;
@@ -69,6 +72,7 @@ fragment <<EOF
 EOF
 
 case ${target} in
+  aarch64-*-mingw* | aarch64-*-pe* | aarch64-*-cygwin | \
   x86_64-*-mingw* | x86_64-*-pe | x86_64-*-pep | x86_64-*-cygwin | \
   i[3-7]86-*-mingw32* | i[3-7]86-*-cygwin* | i[3-7]86-*-winnt | i[3-7]86-*-pe)
 fragment <<EOF

--- a/ld/emultempl/pep.em
+++ b/ld/emultempl/pep.em
@@ -7,6 +7,10 @@ else
 fi
 
 case ${target} in
+  aarch64-*-cygwin*)
+    move_default_addr_high=1
+    cygwin_behavior=0;
+    ;;
   *-*-cygwin*)
     move_default_addr_high=1
     cygwin_behavior=1
@@ -78,9 +82,9 @@ fragment <<EOF
 EOF
 
 case ${target} in
+  aarch64-*-mingw* | aarch64-*-pe* | aarch64-*-cygwin | \
   x86_64-*-mingw* | x86_64-*-pe | x86_64-*-pep | x86_64-*-cygwin | \
-  i[3-7]86-*-mingw32* | i[3-7]86-*-cygwin* | i[3-7]86-*-winnt | i[3-7]86-*-pe | \
-  aarch64-*-mingw* | aarch64-*-pe* )
+  i[3-7]86-*-mingw32* | i[3-7]86-*-cygwin* | i[3-7]86-*-winnt | i[3-7]86-*-pe)
 fragment <<EOF
 #include "pdb.h"
 EOF

--- a/readline/readline/support/config.guess
+++ b/readline/readline/support/config.guess
@@ -947,6 +947,9 @@ EOF
     i*:UWIN*:*)
 	GUESS=$UNAME_MACHINE-pc-uwin
 	;;
+    aarch64:CYGWIN*:*:*)
+	GUESS=aarch64-pc-cygwin
+	;;
     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
 	GUESS=x86_64-pc-cygwin
 	;;


### PR DESCRIPTION
This PR adds upstream Cygwin patche to the binutils as a separate commit and then adds \`aarch64-pc-cygwin\` target support.

Tested by: 
- https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/12298556694
- https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/12298556702
- https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/12298951868