### PR TITLE
Allow build of `libsim` for `aarch64-w64-mingw32` and `aarch64-pc-cygwin`

### DIFF
--- a/gdb/configure.tgt
+++ b/gdb/configure.tgt
@@ -138,6 +138,10 @@ aarch64*-*-elf | aarch64*-*-rtems*)
 	gdb_target_obs="aarch64-newlib-tdep.o"
 	;;
 
+aarch64-*-mingw* | aarch64-*-cygwin*)
+	gdb_target_obs="windows-tdep.o"
+	;;
+
 aarch64*-*-freebsd*)
 	# Target: FreeBSD/aarch64
 	gdb_target_obs="aarch64-fbsd-tdep.o"


### PR DESCRIPTION
This is by no mean a proper implementation of `libsim` or `gdb` support but allows removing `--disable-sim` workaround from binutils build for `aarch64-w64-mingw32` and `aarch64-pc-cygwin` targets.

Validated by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/pull/304.